### PR TITLE
Unused variable warning in realease build surpressed

### DIFF
--- a/mdstorage.hpp
+++ b/mdstorage.hpp
@@ -161,7 +161,7 @@ public:
         requires /**/ (sizeof...(Unsigned) == size)
     consteval explicit basis(Unsigned... extents) noexcept
     : basis(layout_order{}, extents...) {
-        for (auto e: basis::extents) {
+        for ([[maybe_unused]] auto e: basis::extents) {
             assert(e != 0);
         }
     };


### PR DESCRIPTION
`pcx::basis` constructor has for-loop that checks input variable with `assert`. When building in release mode, clang with `-Wall` flag throws a warning about unused for-loop variable.

```
 warning: unused variable 'e' [-Wunused-variable]
  164 |         for (auto e: basis::extents) {
      |                   ^
```